### PR TITLE
Add --min-colors option to extract maximal unitigs, where each node has at least --min-colors colors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Usage:
                           color labels of the colors of that unitig. The 
                           unitigs appear in the same order as in the FASTA 
                           file. (default: "")
+      --min-colors arg    Extract maximal unitigs with at least (>=)
+                          min-colors in each node. Can't be used with
+                          --colors-out. (optional) (default: 0)
   -v, --verbose           More verbose progress reporting into stderr.
   -h, --help              Print usage
 ```

--- a/include/Coloring.hh
+++ b/include/Coloring.hh
@@ -216,6 +216,22 @@ public:
         
     }
 
+    // Returns number of colors for the node
+    LL get_colorset_size(LL node, BOSS<sdsl::bit_vector>& boss) {
+	LL colorset_id = get_colorset_id(node, boss);
+        if(colorset_id == -1) return 0;
+
+        LL start = color_set_starts_ss.select(colorset_id+1);
+        LL pos = start; // Position in internal color array
+        LL idx = 0; // Position in outpuf buffer
+        while(true){
+            idx++;
+            if(pos == color_sets.size()-1 || color_set_starts[pos+1] == 1) break;
+            pos++;
+        }
+        return idx;
+    }
+
     // Returns -1 if the colorset is empty. Otherwise returns the id of the colorset.
     LL get_colorset_id(LL node, BOSS<sdsl::bit_vector>& boss){
         if(node == 0) return -1; // Root

--- a/include/extract_unitigs.hh
+++ b/include/extract_unitigs.hh
@@ -106,6 +106,45 @@ private:
         return colored_unitigs;
     }
 
+    // Extracts maximal unitigs that have at least n_min_colors colors
+    vector<Colored_Unitig> split_by_colorset_size(const LL n_min_colors, Unitig& U, Themisto& themisto){
+        vector<Colored_Unitig> colored_unitigs;
+        auto get_n_colors = [&](LL node){return themisto.coloring.get_colorset_size(node, themisto.boss);};
+
+	LL run_start = 0;
+	while (run_start < U.nodes.size()) {
+	    LL n_colors_for_node = get_n_colors(U.nodes[run_start]);
+
+	    if (n_colors_for_node >= n_min_colors) {
+		LL run_end = run_start;
+		while(run_end < U.nodes.size()-1 && get_n_colors(U.nodes[run_end + 1]) >= n_min_colors){
+		    run_end++;
+		}
+
+		Colored_Unitig colored;
+		for(LL i = run_start; i <= run_end; i++)
+		    colored.nodes.push_back(U.nodes[i]);
+
+		colored.id = U.nodes[run_start];
+
+		colored_unitigs.push_back(colored); // Links are added later
+
+		run_start = run_end;
+	    }
+	    ++run_start;
+	}
+
+        // Linkage
+        for(LL i = 0; i < colored_unitigs.size(); i++){
+            if(i < (LL)colored_unitigs.size()-1) // Not last
+                colored_unitigs[i].links.push_back(colored_unitigs[i+1].id); // Chain unitigs
+            else // Last
+                colored_unitigs[i].links = U.links; // The outgoing links of the original unitig
+        }
+
+        return colored_unitigs;
+    }
+
     string get_unitig_string(vector<LL>& nodes, Themisto& themisto){
         if(nodes.size() == 0) return "";
         string first_kmer = themisto.boss.get_node_label(nodes[0]);
@@ -158,8 +197,13 @@ public:
             if(!visited[v]){
                 Unitig U = get_node_unitig_containing(v, boss, visited);
                 for(LL i = 0; i < U.nodes.size(); i++) pp.job_done(); // Record progress
-                if(split_by_colorset_runs){
-                    for(Colored_Unitig& CU : split_to_colorset_runs(U, themisto)){
+		if (false) {
+		    for(Colored_Unitig& CU : split_by_colorset_size(1117, U, themisto)){ // HARDOCDED colorset size!
+                        write_unitig(CU.nodes, CU.id, themisto, unitigs_out, gfa_out);
+                        write_linkage(CU.id, CU.links, gfa_out, boss.get_k());
+		    }
+		} else if(split_by_colorset_runs){
+		    for(Colored_Unitig& CU : split_to_colorset_runs(U, themisto)){
                         write_unitig(CU.nodes, CU.id, themisto, unitigs_out, gfa_out);
                         write_linkage(CU.id, CU.links, gfa_out, boss.get_k());
                         write_colorset(CU.id, CU.colorset, colorsets_out);

--- a/include/extract_unitigs.hh
+++ b/include/extract_unitigs.hh
@@ -179,10 +179,11 @@ public:
     // If split_by_colorset_runs == true, also splits the unitigs to maximal runs of nodes that have
     // the same colorset, and writes the color sets to colorsets_out. If split_by_colorset_runs == false,
     // then colorsets_out is unused.
+    // If min_colors > 0, extracts maximal unitigs where each node has at least >=min_colors colors.
     // The unitigs are written in fasta-format.
     // The colorsets are written one per line, in the same order as unitigs, in a space-separated format "id c1 c2 ..",
     // where id is the fasta header of the colorset, and c1 c2... are the colors.
-    void extract_unitigs(Themisto& themisto, ostream& unitigs_out, bool split_by_colorset_runs, ostream& colorsets_out, ostream& gfa_out){
+    void extract_unitigs(Themisto& themisto, ostream& unitigs_out, bool split_by_colorset_runs, ostream& colorsets_out, ostream& gfa_out, LL min_colors = 0){
         BOSS<sdsl::bit_vector>& boss = themisto.boss;
 
         gfa_out << "H" << "\t" << "VN:Z:1.0" << "\n"; // Header
@@ -197,8 +198,8 @@ public:
             if(!visited[v]){
                 Unitig U = get_node_unitig_containing(v, boss, visited);
                 for(LL i = 0; i < U.nodes.size(); i++) pp.job_done(); // Record progress
-		if (false) {
-		    for(Colored_Unitig& CU : split_by_colorset_size(1117, U, themisto)){ // HARDOCDED colorset size!
+		if (min_colors > 0) {
+		    for(Colored_Unitig& CU : split_by_colorset_size(min_colors, U, themisto)){
                         write_unitig(CU.nodes, CU.id, themisto, unitigs_out, gfa_out);
                         write_linkage(CU.id, CU.links, gfa_out, boss.get_k());
 		    }

--- a/src/extract_unitigs_main.cpp
+++ b/src/extract_unitigs_main.cpp
@@ -18,6 +18,7 @@ int extract_unitigs_main(int argc, char** argv){
         ("fasta-out", "Output filename for the unitigs in FASTA format (optional).", cxxopts::value<string>()->default_value(""))
         ("gfa-out", "Output the unitig graph in GFA1 format (optional).", cxxopts::value<string>()->default_value(""))
         ("colors-out", "Output filename for the unitig colors (optional). If this option is not given, the colors are not computed. Note that giving this option affects the unitigs written to unitigs-out: if a unitig has nodes with different color sets, the unitig is split into maximal segments of nodes that have equal color sets. The file format of the color file is as follows: there is one line for each unitig. The lines contain space-separated strings. The first string on a line is the FASTA header of a unitig (without the '>'), and the following strings on the line are the integer color labels of the colors of that unitig. The unitigs appear in the same order as in the FASTA file.", cxxopts::value<string>()->default_value(""))
+        ("min-colors", "Extract maximal unitigs with at least (>=) min-colors in each node. Can't be used with --colors-out. (optional)", cxxopts::value<LL>()->default_value("0"))
         ("v,verbose", "More verbose progress reporting into stderr.", cxxopts::value<bool>()->default_value("false"))
         ("silent", "Print as little as possible to stderr (only errors).", cxxopts::value<bool>()->default_value("false"))
         ("h,help", "Print usage")
@@ -39,7 +40,8 @@ int extract_unitigs_main(int argc, char** argv){
     string unitigs_outfile = opts["fasta-out"].as<string>();
     string gfa_outfile = opts["gfa-out"].as<string>();
     string colors_outfile = opts["colors-out"].as<string>();
-    bool do_colors = (colors_outfile != "");
+    LL min_colors = opts["min-colors"].as<LL>();
+    bool do_colors = (colors_outfile != "") || min_colors > 0;
     string index_dbg_file = opts["index-prefix"].as<string>() + ".tdbg";
     string index_color_file = opts["index-prefix"].as<string>() + ".tcolors";
     
@@ -48,6 +50,9 @@ int extract_unitigs_main(int argc, char** argv){
     
     if(unitigs_outfile == "" && colors_outfile == "" && gfa_outfile == ""){
         throw std::runtime_error("Error: no output files given");
+    }
+    if (colors_outfile != "" && min_colors != 0) { // Colors may not make sense for --min-colors
+	throw std::runtime_error("Error: Colorset extraction not allowed when --min-colors is given");
     }
     
     // Prepare output streams
@@ -88,7 +93,7 @@ int extract_unitigs_main(int argc, char** argv){
     write_log("Extracting unitigs", LogLevel::MAJOR);
     
     UnitigExtractor UE;
-    UE.extract_unitigs(themisto, *unitigs_out, do_colors, *colors_out, *gfa_out);
+    UE.extract_unitigs(themisto, *unitigs_out, do_colors, *colors_out, *gfa_out, min_colors);
 
     return 0;
     


### PR DESCRIPTION
Moi,

I expanded the functionality of extract-unitigs a bit to allow for extracting maximal unitigs which have at least some number of colors assigned to each node. This is done by adding the `--min-colors` option to the subprogram, where the argument defines the number of colors that are required. Colorset extraction isn't allowed when `--min-colors` is used since I assumed that the unitigs might not have the same colorset for every node.