### PR TITLE
Print pseudoalignments if the output file `-o` is not given.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Usage:
 
 This command aligns query sequences against an index that has been built previously. The output is one line per input read. Each line consists of a space-separated list of integers. The first integer specifies the rank of the read in the input file, and the rest of the integers are the identifiers of the colors of the sequences that the read pseudoaligns with. If the program is ran with more than one thread, the output lines are not necessarily in the same order as the reads in the input file. This can be fixed with the option --sort-output.
 
-The query can be given as one file, or as a file with a list of files. In the former case, we must specify one output file with the options --out-file, and in the latter case, we must give a file that lists one output filename per line using the option --out-file-list.
+The query can be given as one file, or as a file with a list of files. In the former case, one output file can be specified with the option --out-file. If --out-file is not given, the results will be print to cout. In the latter case, we must give a file that lists one output filename per line using the option --out-file-list.
 
 The query file(s) should be in fasta of fastq format. The format is inferred from the file extension. Recognized file extensions for fasta are: .fasta, .fna, .ffn, .faa and .frn . Recognized extensions for fastq are: .fastq and .fq
 
@@ -162,7 +162,8 @@ Usage:
                              "")
       --query-file-list arg  A list of query filenames, one line per 
                              filename (default: "")
-  -o, --out-file arg         Output filename. (default: "")
+  -o, --out-file arg         Output filename. Print results
+                             if no output filename is given. (default: "")
       --out-file-list arg    A file containing a list of output filenames, 
                              one per line. (default: "")
   -i, --index-prefix arg     The index prefix that was given to the build 
@@ -180,7 +181,12 @@ Usage:
 
 Examples:
 
-Pseudoalign reads.fna against an index:
+Pseudoalign reads.fna against an index and print results:
+```
+./build/bin/themisto pseudoalign --query-file reads.fna --index-prefix my_index --temp-dir temp
+```
+
+Pseudoalign reads.fna against an index and write results to out.txt:
 ```
 ./build/bin/themisto pseudoalign --query-file reads.fna --index-prefix my_index --temp-dir temp --out-file out.txt
 ```

--- a/include/Themisto.hh
+++ b/include/Themisto.hh
@@ -403,8 +403,13 @@ public:
 
     void pseudoalign_parallel(LL n_threads, Sequence_Reader_Buffered& sr, string outfile, bool reverse_complements, LL buffer_size, bool gzipped_output, bool sort_after){
         ParallelBaseWriter* out = nullptr;
-        if(gzipped_output) out = new ParallelGzipWriter(outfile);
-        else out = new ParallelOutputWriter(outfile);
+	if (!outfile.empty()) {
+	    if(gzipped_output) out = new ParallelGzipWriter(outfile);
+	    else out = new ParallelOutputWriter(outfile);
+	} else {
+	    if(gzipped_output) out = new ParallelGzipWriter(cout);
+	    else out = new ParallelOutputWriter(cout);
+	}
 
         vector<DispatcherConsumerCallback*> threads;
         for(LL i = 0; i < n_threads; i++){
@@ -430,7 +435,7 @@ public:
                 throwing_ifstream instream(outfile);
                 throwing_ofstream outstream(tempfile);
                 sort_parallel_output_file(instream, outstream);
-            }
+	    }
             std::filesystem::rename(tempfile, outfile);
         }
     }


### PR DESCRIPTION
Enable printing `themisto pseudoalign` results to cout if the outfile option `-o` is not given. This is done by implementing new constructors for Buffered_ofstream, ParallelOutputWriter, and ParallelGzipWriter that take an std::ostream as their argument, and modifying the pseudoalign code to use these constructors with cout as the argumen when the output file is not specified or is empty.

Behaviour:
- Print to cout if `-o` is not given.
- Only print if unsorted output is requested since the sorting requires storing the output to disk anyway.
- Only print if aligning a single file (--query-file-list not specified).
