### PR TITLE
Return `0` from main if ran with `--help` or without any arguments.

### DIFF
--- a/src/themisto_main.cpp
+++ b/src/themisto_main.cpp
@@ -31,13 +31,13 @@ int main(int argc, char** argv){
 
     if(argc == 1){
         print_help(argc, argv);
-        return 1;
+        return 0;
     }
 
     string command = argv[1];
     if(command == "--help" || command == "-h"){
         print_help(argc, argv);
-        return 1;
+        return 0;
     }
 
     // Drop the first element of argv


### PR DESCRIPTION
Change return value from running `themisto` or `themisto --help` to `0` since printing the help message when requested is not an error (helps in setting up conda distribution).