### PR TITLE
Update ggcat (track algbio/ggcat, update version)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/algbio/SBWT
 [submodule "ggcat"]
 	path = ggcat
-	url = https://github.com/jnalanko/ggcat
+	url = https://github.com/algbio/ggcat


### PR DESCRIPTION
Fix build issues related to ggcat (https://github.com/algbio/ggcat/issues/31) by tracking [algbio/ggcat](https://github.com/algbio/ggcat) and updating the submodule version.