### PR TITLE
Fix workflow for generating binaries

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_linux-x86_64:
     runs-on: ubuntu-latest
-    container: phusion/holy-build-box-64:3.0.2
+    container: phusion/holy-build-box:4.0.1
     steps:
       - name: Install wget
         id: install-wget


### PR DESCRIPTION
The workflow needs to be updated to the new version of HBB to generate the Linux binaries due issues with yum repositories in the previous version.